### PR TITLE
add `docker` env

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -16,3 +16,6 @@ development: &default
 test:
   <<: *default
   database: tariff_admin_test
+
+docker:
+  <<: *default

--- a/config/environments/docker.rb
+++ b/config/environments/docker.rb
@@ -1,0 +1,67 @@
+TradeTariffAdmin::Application.configure do
+  # Settings specified here will take precedence over those in config/application.rb
+
+  # Code is not reloaded between requests
+  config.cache_classes = true
+
+  # Full error reports are disabled and caching is turned on
+  config.consider_all_requests_local       = false
+  config.action_controller.perform_caching = true
+
+  # Compress JavaScripts and CSS
+  config.assets.compress = true
+
+  # Don't fallback to assets pipeline if a precompiled asset is missed
+  config.assets.compile = true
+
+  # Specifies the header that your server uses for sending files
+  # config.action_dispatch.x_sendfile_header = "X-Sendfile" # for apache
+  # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for nginx
+
+  # See everything in the log (default is :info)
+  # config.log_level = :debug
+
+  # Prepend all log lines with the following tags
+  # config.log_tags = [ :subdomain, :uuid ]
+
+  # Use a different logger for distributed setups
+  # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
+
+  # Enable serving of images, stylesheets, and JavaScripts from an asset server
+  # config.action_controller.asset_host = "http://assets.example.com"
+
+  # Precompile additional assets (application.js, application.css, and all non-JS/CSS are already added)
+  # config.assets.precompile += %w( search.js )
+
+  # Disable delivery errors, bad email addresses will be ignored
+  # config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.delivery_method = :ses
+
+  # Enable threaded mode
+  # config.threadsafe!
+
+  # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
+  # the I18n.default_locale when a translation can not be found)
+  config.i18n.fallbacks = true
+
+  # Send deprecation notices to registered listeners
+  config.active_support.deprecation = :notify
+
+  # Log the query plan for queries taking more than this (works
+  # with SQLite, MySQL, and PostgreSQL)
+  # config.active_record.auto_explain_threshold_in_seconds = 0.5
+
+  # Log the query plan for queries taking more than this (works
+  # with SQLite, MySQL, and PostgreSQL)
+  # config.active_record.auto_explain_threshold_in_seconds = 0.5
+
+  # Host for Trade Tariff API endpoint
+  config.api_host = "http://tariff-api.dev.gov.uk:3018"
+
+  config.eager_load = true
+
+  # # Enable JSON-style logging
+  # config.logstasher.enabled = true
+  # config.logstasher.logger = Logger.new("#{Rails.root}/log/#{Rails.env}.json.log")
+  # config.logstasher.supress_app_log = true
+end

--- a/config/initializers/gds-sso.rb
+++ b/config/initializers/gds-sso.rb
@@ -1,3 +1,5 @@
+require_relative '../../lib/gds-sso/config'
+
 GDS::SSO.config do |config|
   config.user_model   = "User"
   config.oauth_id     = ENV['TARIFF_ADMIN_OAUTH_ID'] || "abcdefghjasndjkasndtariffadmin"

--- a/config/initializers/raven.rb
+++ b/config/initializers/raven.rb
@@ -1,6 +1,6 @@
 require "raven"
 
 Raven.configure do |config|
-  config.environments = %w[ development ]
+  config.environments = %w[ docker ]
   config.dsn = "https://3bee46b6981347afbf075c2179190c94:1cdaa52a99be454eb995830c1306b811@app.getsentry.com/30337"
 end

--- a/lib/gds-sso/config.rb
+++ b/lib/gds-sso/config.rb
@@ -1,0 +1,9 @@
+module GDS
+  module SSO
+    module Config
+      def self.use_mock_strategies?
+        ['development', 'test', 'docker'].include?(Rails.env) && ENV['GDS_SSO_STRATEGY'] != 'real'
+      end
+    end
+  end
+end

--- a/startup.sh
+++ b/startup.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-
+export RAILS_ENV=docker
 bundle install
 bundle exec unicorn -p 3046


### PR DESCRIPTION
- use it by default on `startup.sh` (called by docker containers)
- copied from `production`, uses some caching and it's faster than `development`
- log this env's errors on sentry
- mock gds-sso authentication when running under `docker` env
