### PR TITLE
mount sidekiq web

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,9 @@ gem "logstasher", "~> 0.6"
 gem "airbrake", "~> 4.3"
 gem "responders", "~> 2.1"
 
+gem "sidekiq", "~> 4.1.1"
+gem "sinatra", "~> 1.4.7", require: nil
+
 group :development, :test do
   gem "pry-rails"
   gem "brakeman", "~> 3.0", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,6 +79,7 @@ GEM
       execjs
     coffee-script-source (1.9.1)
     concurrent-ruby (1.0.1)
+    connection_pool (2.2.0)
     crack (0.4.2)
       safe_yaml (~> 1.0.0)
     database_cleaner (1.4.1)
@@ -181,6 +182,8 @@ GEM
     rack (1.6.4)
     rack-accept (0.4.5)
       rack (>= 0.4)
+    rack-protection (1.5.3)
+      rack
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (4.2.5.1)
@@ -214,6 +217,7 @@ GEM
       thor (>= 0.18.1, < 2.0)
     raindrops (0.15.0)
     rake (10.5.0)
+    redis (3.2.2)
     ref (2.0.0)
     request_store (1.2.0)
     responders (2.1.0)
@@ -260,6 +264,10 @@ GEM
     sexp_processor (4.6.0)
     shoulda-matchers (2.8.0)
       activesupport (>= 3.0.0)
+    sidekiq (4.1.1)
+      concurrent-ruby (~> 1.0)
+      connection_pool (~> 2.2, >= 2.2.0)
+      redis (~> 3.2, >= 3.2.1)
     simple_form (3.1.0)
       actionpack (~> 4.0)
       activemodel (~> 4.0)
@@ -270,6 +278,10 @@ GEM
     simplecov-html (0.10.0)
     simplecov-rcov (0.2.3)
       simplecov (>= 0.4.1)
+    sinatra (1.4.7)
+      rack (~> 1.5)
+      rack-protection (~> 1.4)
+      tilt (>= 1.3, < 3)
     slop (3.6.0)
     sprockets (3.5.2)
       concurrent-ruby (~> 1.0)
@@ -336,9 +348,11 @@ DEPENDENCIES
   rspec_junit_formatter
   sass-rails (~> 5.0)
   shoulda-matchers
+  sidekiq (~> 4.1.1)
   simple_form (~> 3.1)
   simplecov
   simplecov-rcov
+  sinatra (~> 1.4.7)
   therubyracer (~> 0.12)
   uglifier (~> 2.7)
   unicorn (~> 4.9)

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,9 @@
+url = Rails.application.secrets.redis_url || "redis://localhost:6379/12"
+
+Sidekiq.configure_server do |config|
+  config.redis = { url: url }
+end
+
+Sidekiq.configure_client do |config|
+  config.redis = { url: url }
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,6 @@
+require "sidekiq/web"
+require "gds_editor_constraint"
+
 Rails.application.routes.draw do
   namespace :notes, module: :notes do
     resources :sections, only: [:index, :show] do
@@ -52,5 +55,6 @@ Rails.application.routes.draw do
   post "govspeak" => "govspeak#govspeak", as: :govspeak
   get  "healthcheck" => "healthcheck#check", as: :healthcheck
   get  "/" => "pages#index", as: :index
+  mount Sidekiq::Web => "/sidekiq", constraints: GdsEditorConstraint.new
   root to: "pages#index"
 end

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -25,3 +25,4 @@ production:
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
   errbit_host: <%= ENV["ERRBIT_HOST"] %>
   errbit_api_key: <%= ENV["ERRBIT_API_KEY"] %>
+  redis_url: <%= ENV["REDIS_URL"] %>

--- a/lib/gds_editor_constraint.rb
+++ b/lib/gds_editor_constraint.rb
@@ -1,0 +1,23 @@
+class GdsEditorConstraint
+  attr_reader :request
+
+  def matches?(request)
+    @request = request
+    warden.authenticate!
+    current_user && current_user.gds_editor?
+  end
+
+  private
+
+  def warden
+    request.env['warden']
+  end
+
+  def current_user
+    warden.user if user_signed_in?
+  end
+
+  def user_signed_in?
+    warden && warden.authenticated? && ! warden.user.remotely_signed_out?
+  end
+end


### PR DESCRIPTION
and restrict to users with gds_editor permission.

backend app uses sidekiq to perform background jobs. this commit enables us to connect to the backend’s scheduler database and have a view on the background jobs.