### PR TITLE
Allow set API host with an Env var

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -40,5 +40,5 @@ Rails.application.configure do
   # config.action_view.raise_on_missing_translations = true
 
   # Host for Trade Tariff API endpoint
-  config.api_host = "http://tariff-api.dev.gov.uk"
+  config.api_host = ENV["TARIFF_API_HOST"] || "http://tariff-api.dev.gov.uk"
 end


### PR DESCRIPTION
Allow to define the api_host with an enviroment variable, like the frontend app https://github.com/bitzesty/trade-tariff-frontend/blob/cf/config/environments/development.rb#L28