### PR TITLE
Update govuk_admin_template gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem "kaminari", "~> 0.16"
 gem "simple_form", "~> 3.1"
 gem "govspeak", "~> 3.4"
 
-gem 'govuk_admin_template', '3.0.0'
+gem 'govuk_admin_template', '4.1.1'
 
 gem "gds-sso", "~> 11.0"
 gem "plek", "~> 1.11"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,9 +41,8 @@ GEM
       builder
       multi_json
     arel (6.0.3)
-    autoprefixer-rails (6.0.3)
+    autoprefixer-rails (6.3.3.1)
       execjs
-      json
     bootstrap-datepicker-rails (1.4.0)
       railties (>= 3.0)
     bootstrap-sass (3.3.5.1)
@@ -79,7 +78,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.9.1)
-    concurrent-ruby (1.0.0)
+    concurrent-ruby (1.0.1)
     crack (0.4.2)
       safe_yaml (~> 1.0.0)
     database_cleaner (1.4.1)
@@ -111,8 +110,8 @@ GEM
       kramdown (~> 1.5.0)
       nokogiri (~> 1.5)
       sanitize (~> 2.1.0)
-    govuk_admin_template (3.0.0)
-      bootstrap-sass (~> 3.3.3)
+    govuk_admin_template (4.1.1)
+      bootstrap-sass (= 3.3.5.1)
       jquery-rails (~> 3.1.3)
       rails (>= 3.2.0)
     haml (4.0.6)
@@ -126,7 +125,7 @@ GEM
     highline (1.6.21)
     htmlentities (4.3.4)
     i18n (0.7.0)
-    jquery-rails (3.1.3)
+    jquery-rails (3.1.4)
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
     json (1.8.3)
@@ -146,7 +145,7 @@ GEM
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
     method_source (0.8.2)
-    mime-types (2.99)
+    mime-types (2.99.1)
     mini_portile2 (2.0.0)
     minitest (5.8.4)
     multi_json (1.11.2)
@@ -251,7 +250,7 @@ GEM
     safe_yaml (1.0.4)
     sanitize (2.1.0)
       nokogiri (>= 1.4.4)
-    sass (3.4.16)
+    sass (3.4.21)
     sass-rails (5.0.3)
       railties (>= 4.0.0, < 5.0)
       sass (~> 3.1)
@@ -275,7 +274,7 @@ GEM
     sprockets (3.5.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
-    sprockets-rails (3.0.0)
+    sprockets-rails (3.0.4)
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
@@ -321,7 +320,7 @@ DEPENDENCIES
   factory_girl_rails
   gds-sso (~> 11.0)
   govspeak (~> 3.4)
-  govuk_admin_template (= 3.0.0)
+  govuk_admin_template (= 4.1.1)
   her (= 0.6.8)
   jquery-rails (~> 3.1.1)
   kaminari (~> 0.16)

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -8,5 +8,4 @@ Rails.application.config.assets.version = '1.0'
 
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
-
-Rails.application.config.assets.precompile += %w( govuk_admin_template/favicon.png )
+# Rails.application.config.assets.precompile += %w( search.js )


### PR DESCRIPTION
While running the application I found some issues related to assets pre-compilation missing, we can see these errors now that rails was updated and it's checked also in development.

After adding the required line, I notices this was required by an external gem, `govuk_admin_template` the good news is that the new version already handle this for us :tada: 