### PR TITLE
Replace Airbrake with Sentry

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,6 @@ gem "puma"
 gem "jquery-rails", "~> 3.1.1"
 gem "bootstrap-datepicker-rails", "~> 1.4"
 gem "logstasher", "~> 0.6"
-gem "airbrake", "~> 4.3"
 gem "responders", "~> 2.1"
 
 gem "sidekiq", "~> 4.1.1"
@@ -52,4 +51,5 @@ end
 group :production do
   gem "therubyracer", "~> 0.12"
   gem "rails_12factor"
+  gem "sentry-raven"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,9 +37,6 @@ GEM
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     addressable (2.3.8)
-    airbrake (4.3.0)
-      builder
-      multi_json
     arel (6.0.3)
     autoprefixer-rails (6.3.3.1)
       execjs
@@ -260,6 +257,8 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (~> 1.1)
+    sentry-raven (0.15.6)
+      faraday (>= 0.7.6)
     sexp_processor (4.6.0)
     shoulda-matchers (2.8.0)
       activesupport (>= 3.0.0)
@@ -316,7 +315,6 @@ PLATFORMS
 
 DEPENDENCIES
   addressable (~> 2.3)
-  airbrake (~> 4.3)
   bootstrap-datepicker-rails (~> 1.4)
   brakeman (~> 3.0)
   capybara (~> 2.4)
@@ -343,6 +341,7 @@ DEPENDENCIES
   rspec-rails
   rspec_junit_formatter
   sass-rails (~> 5.0)
+  sentry-raven
   shoulda-matchers
   sidekiq (~> 4.1.1)
   simple_form (~> 3.1)

--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -1,6 +1,0 @@
-Airbrake.configure do |config|
-  config.port    = 443
-  config.secure  = true
-  config.host    = Rails.application.secrets.errbit_host
-  config.api_key = Rails.application.secrets.errbit_api_key
-end

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -23,6 +23,4 @@ test:
 production:
   secret_token: <%= ENV["SECRET_TOKEN"] %>
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
-  errbit_host: <%= ENV["ERRBIT_HOST"] %>
-  errbit_api_key: <%= ENV["ERRBIT_API_KEY"] %>
   redis_url: <%= ENV["REDIS_URL"] %>


### PR DESCRIPTION
Set your SENTRY_DSN environment variable and the gem will capture and
send exceptions to the Sentry server.

Raven only runs when SENTRY_DSN is set