### PR TITLE
Sidekiq updates

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ gem "logstasher", "~> 0.6"
 gem "responders", "~> 2.1"
 
 gem "sidekiq", "~> 4.1.1"
+gem "sidekiq-scheduler", "~> 2.0"
 gem "sinatra", "~> 1.4.7", require: nil
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -247,6 +247,7 @@ GEM
       sexp_processor (~> 4.0)
     ruby_parser (3.7.0)
       sexp_processor (~> 4.1)
+    rufus-scheduler (3.1.10)
     safe_yaml (1.0.4)
     sanitize (2.1.0)
       nokogiri (>= 1.4.4)
@@ -266,6 +267,12 @@ GEM
       concurrent-ruby (~> 1.0)
       connection_pool (~> 2.2, >= 2.2.0)
       redis (~> 3.2, >= 3.2.1)
+    sidekiq-scheduler (2.0.6)
+      multi_json (~> 1)
+      redis (~> 3)
+      rufus-scheduler (~> 3.1.8)
+      sidekiq (>= 3)
+      tilt (>= 1.4.0)
     simple_form (3.1.0)
       actionpack (~> 4.0)
       activemodel (~> 4.0)
@@ -344,6 +351,7 @@ DEPENDENCIES
   sentry-raven
   shoulda-matchers
   sidekiq (~> 4.1.1)
+  sidekiq-scheduler (~> 2.0)
   simple_form (~> 3.1)
   simplecov
   simplecov-rcov

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,9 +1,0 @@
-url = Rails.application.secrets.redis_url || "redis://localhost:6379/12"
-
-Sidekiq.configure_server do |config|
-  config.redis = { url: url }
-end
-
-Sidekiq.configure_client do |config|
-  config.redis = { url: url }
-end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 require "sidekiq/web"
+require "sidekiq-scheduler/web"
 require "gds_editor_constraint"
 
 Rails.application.routes.draw do

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -23,4 +23,3 @@ test:
 production:
   secret_token: <%= ENV["SECRET_TOKEN"] %>
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
-  redis_url: <%= ENV["REDIS_URL"] %>


### PR DESCRIPTION
#### What this PR does:

- Adds the sidekiq-scheduler gem, in order to display the recurring jobs tab.
- Delete unnecessary `config/initializers/sidekiq.rb` file.

#### Notes

Sidekiq will connect by default to localhost, but if the REDIS_URL env var is present will use that url for connecting to redis.
