### PR TITLE
Remove referenced association from Search Reference model

### DIFF
--- a/app/controllers/synonyms/chapters/search_references_controller.rb
+++ b/app/controllers/synonyms/chapters/search_references_controller.rb
@@ -1,19 +1,6 @@
 module Synonyms
   module Chapters
     class SearchReferencesController < Synonyms::SearchReferencesController
-      def update
-        search_reference.referenced_id = search_reference.referenced_entity.id
-        search_reference.referenced_class = 'Chapter'
-
-        super
-      end
-
-      def destroy
-        search_reference.referenced_id = search_reference.referenced_entity.id
-
-        super
-      end
-
       private
 
       def search_reference_parent

--- a/app/controllers/synonyms/commodities/search_references_controller.rb
+++ b/app/controllers/synonyms/commodities/search_references_controller.rb
@@ -1,19 +1,6 @@
 module Synonyms
   module Commodities
     class SearchReferencesController < Synonyms::SearchReferencesController
-      def update
-        search_reference.referenced_id = search_reference.referenced_entity.id
-        search_reference.referenced_class = 'Commodity'
-
-        super
-      end
-
-      def destroy
-        search_reference.referenced_id = search_reference.referenced_entity.id
-
-        super
-      end
-
       private
 
       def search_reference_parent

--- a/app/controllers/synonyms/headings/search_references_controller.rb
+++ b/app/controllers/synonyms/headings/search_references_controller.rb
@@ -1,19 +1,6 @@
 module Synonyms
   module Headings
     class SearchReferencesController < Synonyms::SearchReferencesController
-      def update
-        search_reference.referenced_id = search_reference.referenced_entity.id
-        search_reference.referenced_class = 'Heading'
-
-        super
-      end
-
-      def destroy
-        search_reference.referenced_id = search_reference.referenced_entity.id
-
-        super
-      end
-
       private
 
       def search_reference_parent

--- a/app/controllers/synonyms/sections/search_references_controller.rb
+++ b/app/controllers/synonyms/sections/search_references_controller.rb
@@ -1,19 +1,6 @@
 module Synonyms
   module Sections
     class SearchReferencesController < Synonyms::SearchReferencesController
-      def update
-        search_reference.referenced_id = search_reference.referenced_entity.id
-        search_reference.referenced_class = 'Section'
-
-        super
-      end
-
-      def destroy
-        search_reference.referenced_id = search_reference.referenced_entity.id
-
-        super
-      end
-
       private
 
       def search_reference_parent

--- a/app/models/search_reference.rb
+++ b/app/models/search_reference.rb
@@ -4,14 +4,13 @@ class SearchReference
   include_root_in_json true
 
   attributes :title
-  attributes :referenced
   attributes :referenced_id
   attributes :referenced_class
 
   validates :title, presence: true
 
   def referenced_entity
-    referenced_class.new(attributes['referenced'])
+    referenced_class.find(referenced_id)
   end
 
   def referenced_class

--- a/spec/factories/search_reference_factory.rb
+++ b/spec/factories/search_reference_factory.rb
@@ -8,26 +8,34 @@ FactoryGirl.define do
   end
 
   factory :section_search_reference, parent: :search_reference, class: Section::SearchReference do
-    referenced { attributes_for(:section) }
-    referenced_id { referenced[:id] }
+    transient do
+      referenced attributes_for(:section)
+    end
     referenced_class { 'Section' }
+    referenced_id { referenced[:id] }
   end
 
   factory :chapter_search_reference, parent: :search_reference, class: Chapter::SearchReference do
+    transient do
+      referenced attributes_for(:chapter)
+    end
     referenced_class { 'Chapter' }
-    referenced { attributes_for(:chapter) }
     referenced_id { referenced[:goods_nomenclature_item_id].first(2) }
   end
 
   factory :heading_search_reference, parent: :search_reference, class: Heading::SearchReference do
+    transient do
+      referenced attributes_for(:heading)
+    end
     referenced_class { 'Heading' }
-    referenced { attributes_for(:heading) }
     referenced_id { referenced[:goods_nomenclature_item_id].first(4) }
   end
 
   factory :commodity_search_reference, parent: :search_reference, class: Commodity::SearchReference do
+    transient do
+      referenced attributes_for(:commodity)
+    end
     referenced_class { 'Commodity' }
-    referenced { attributes_for(:commodity) }
     referenced_id { referenced[:goods_nomenclature_item_id] }
   end
 end

--- a/spec/features/chapter_search_reference_spec.rb
+++ b/spec/features/chapter_search_reference_spec.rb
@@ -7,7 +7,7 @@ describe "Chapter Search Reference management" do
 
   describe "Search Reference creation" do
     let(:title)        { 'new title' }
-    let(:chapter_search_reference) { attributes_for :chapter_search_reference, title: title }
+    let(:chapter_search_reference) { build :chapter_search_reference, title: title, referenced: chapter }
     let(:section)      { build :section }
     let(:chapter)      { build :chapter, :with_section, title: 'new chapter', section: section.attributes }
 
@@ -35,7 +35,6 @@ describe "Chapter Search Reference management" do
           api_success_response([chapter_search_reference], { 'x-meta' => { pagination: { total: 1 } }.to_json })
         }
       }
-
       create_search_reference_for chapter, title: title
 
       verify search_reference_created_for(chapter, title: title)

--- a/spec/features/section_search_reference_spec.rb
+++ b/spec/features/section_search_reference_spec.rb
@@ -15,7 +15,7 @@ describe "Section Search Reference management" do
 
   describe "Search Reference creation" do
     let(:title)        { 'new title' }
-    let(:section_search_reference) { attributes_for :section_search_reference, title: title }
+    let(:section_search_reference) { attributes_for :section_search_reference, title: title, referenced: section }
     let(:section)      { build :section, title: 'new section' }
 
     specify do


### PR DESCRIPTION
#### What this PR does:

The response of the request for Search References has a node called `referenced` which has some expensive operations that make this endpoint slow, but this node is not necessary for the frontend or admin app.

This PR removes the dependency of having this node.