### PR TITLE
Hotfix to production: Upgrade nokogiri

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,8 @@ gem "sidekiq-scheduler", "~> 2.0"
 gem "sinatra", "~> 1.4.7", require: nil
 gem "bootscale", "~> 0.5", require: false
 
+gem "nokogiri", "~> 1.8.1"
+
 group :development, :test do
   gem "pry-rails"
   gem "brakeman", "~> 3.0", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -151,14 +151,14 @@ GEM
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
-    mini_portile2 (2.1.0)
+    mini_portile2 (2.3.0)
     minitest (5.10.1)
     multi_json (1.11.2)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
     newrelic_rpm (3.16.0.318)
-    nokogiri (1.7.1)
-      mini_portile2 (~> 2.1.0)
+    nokogiri (1.8.1)
+      mini_portile2 (~> 2.3.0)
     oauth2 (1.2.0)
       faraday (>= 0.8, < 0.10)
       jwt (~> 1.0)
@@ -353,6 +353,7 @@ DEPENDENCIES
   lograge
   logstash-event
   newrelic_rpm
+  nokogiri (~> 1.8.1)
   pg
   plek (~> 1.11)
   pry-rails


### PR DESCRIPTION
https://snyk.io/vuln/SNYK-RUBY-NOKOGIRI-20432?utm_source=slack

upgrade gem nokogiri to '1.8.1'