### PR TITLE
[cds] Display cds update type and file_date

### DIFF
--- a/app/models/tariff_update.rb
+++ b/app/models/tariff_update.rb
@@ -4,7 +4,7 @@ class TariffUpdate
 
   collection_path '/admin/updates'
 
-  attributes :update_type, :state, :created_at, :updated_at, :applied_at, :filesize,
+  attributes :update_type, :state, :issue_date, :created_at, :updated_at, :applied_at, :filesize,
              :exception_backtrace, :exception_class, :exception_queries, :conformance_errors,
              :file_presigned_url, :log_presigned_urls, :presence_errors
 
@@ -21,6 +21,7 @@ class TariffUpdate
     case attributes[:update_type]
     when /Taric/ then 'TARIC'
     when /Chief/ then 'CHIEF'
+    when /Cds/   then 'CDS'
     end
   end
 
@@ -37,7 +38,11 @@ class TariffUpdate
   end
 
   def file_date
-    filename.try :slice, 0, 10
+    if update_type == 'CDS'
+      Date.parse(issue_date)
+    else
+      filename.try :slice, 0, 10
+    end
   end
 
   def created_at


### PR DESCRIPTION
<img width="1240" alt="Screenshot 2020-10-07 at 21 41 51" src="https://user-images.githubusercontent.com/1684845/95379670-fa9c1c80-08e5-11eb-9bf1-cfa5a64ac28a.png">

https://trello.com/c/N5OcBCFL/7-bring-cds-envrioment-back-up-to-date-by-doing-a-fresh-annual-restore-and-then-applying-all-updates-via-the-api